### PR TITLE
Use IrrationalConstants and do not export logarithmic constants

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.2.5"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 DocStringExtensions = "0.8"
+IrrationalConstants = "0.1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.3.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 DocStringExtensions = "0.8"
+IrrationalConstants = "0.1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,14 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.2.6"
+version = "0.3.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 DocStringExtensions = "0.8"
-IrrationalConstants = "0.1"
 julia = "1"
 
 [extras]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -29,6 +29,11 @@ version = "0.2.2"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[IrrationalConstants]]
+git-tree-sha1 = "f76424439413893a832026ca355fe273e93bce94"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.0"
+
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
@@ -47,7 +52,7 @@ deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
-deps = ["DocStringExtensions", "LinearAlgebra"]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
 path = ".."
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 version = "0.3.0"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -29,11 +29,6 @@ version = "0.2.2"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[IrrationalConstants]]
-git-tree-sha1 = "f76424439413893a832026ca355fe273e93bce94"
-uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.0"
-
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
@@ -52,10 +47,10 @@ deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
-deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+deps = ["DocStringExtensions", "LinearAlgebra"]
 path = ".."
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.2.6"
+version = "0.3.0"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -15,19 +15,24 @@ version = "0.8.5"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "5acbebf1be22db43589bc5aa1bb5fcc378b17780"
+git-tree-sha1 = "47f13b6305ab195edb73c86815962d84e31b0f48"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.0"
+version = "0.27.3"
 
 [[IOCapture]]
-deps = ["Logging"]
-git-tree-sha1 = "1868e4e7ad2f93d8de0904d89368c527b46aa6a1"
+deps = ["Logging", "Random"]
+git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.1"
+version = "0.2.2"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IrrationalConstants]]
+git-tree-sha1 = "f76424439413893a832026ca355fe273e93bce94"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -38,6 +43,19 @@ version = "0.21.1"
 [[LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+path = ".."
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.2.6"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 
 [compat]
 Documenter = "0.27"
-LogExpFunctions = "0.2"
+LogExpFunctions = "0.3"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 
 [compat]
-Documenter = "~0.26, 0.27"
+Documenter = "0.27"
+LogExpFunctions = "0.2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,13 +1,17 @@
 using Documenter, LogExpFunctions
 
-makedocs(
-    modules = [LogExpFunctions],
-    format = Documenter.HTML(),
-    checkdocs = :exports,
-    sitename = "LogExpFunctions.jl",
-    pages = Any["index.md"]
+# Doctest setup
+DocMeta.setdocmeta!(
+    LogExpFunctions, :DocTestSetup, :(using LogExpFunctions); recursive=true
 )
 
-deploydocs(
-    repo = "github.com/JuliaStats/LogExpFunctions.jl.git",
+makedocs(;
+    modules=[LogExpFunctions],
+    format=Documenter.HTML(),
+    sitename="LogExpFunctions.jl",
+    pages=Any["index.md"],
+    checkdocs=:exports,
+    strict=true,
 )
+
+deploydocs(; repo="github.com/JuliaStats/LogExpFunctions.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,3 +21,16 @@ logsumexp
 softmax!
 softmax
 ```
+
+## Constants
+
+Additionally, LogExpFunctions.jl reexports the following logarithmic constants defined in
+[IrrationalConstants.jl](https://github.com/JuliaMath/IrrationalConstants.jl).
+
+```julia
+loghalf    # log(1 / 2)
+logtwo     # log(2)
+logπ       # log(π)
+log2π      # log(2π)
+log4π      # log(4π)
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,6 +17,7 @@ logexpm1
 log1pmx
 logmxp1
 logaddexp
+logsubexp
 logsumexp
 softmax!
 softmax

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,16 +22,3 @@ logsumexp
 softmax!
 softmax
 ```
-
-## Constants
-
-Additionally, LogExpFunctions.jl reexports the following logarithmic constants defined in
-[IrrationalConstants.jl](https://github.com/JuliaMath/IrrationalConstants.jl).
-
-```julia
-loghalf    # log(1 / 2)
-logtwo     # log(2)
-logπ       # log(π)
-log2π      # log(2π)
-log4π      # log(4π)
-```

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -1,7 +1,9 @@
 module LogExpFunctions
 
 using DocStringExtensions: SIGNATURES
-using Base: Math.@horner, @irrational
+using Base: Math.@horner
+
+import IrrationalConstants
 import LinearAlgebra
 
 export xlogx, xlogy, logistic, logit, log1psq, log1pexp, log1mexp, log2mexp, logexpm1,

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -4,12 +4,14 @@ using DocStringExtensions: SIGNATURES
 using Base: Math.@horner, @irrational
 import LinearAlgebra
 
+# reexport logarithmic constants
+using IrrationalConstants: loghalf, logtwo, logπ, log2π, log4π
 export loghalf, logtwo, logπ, log2π, log4π
+
 export xlogx, xlogy, logistic, logit, log1psq, log1pexp, log1mexp, log2mexp, logexpm1,
     softplus, invsoftplus, log1pmx, logmxp1, logaddexp, logsubexp, logsumexp, softmax,
     softmax!
 
-include("constants.jl")
 include("basicfuns.jl")
 include("logsumexp.jl")
 

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -4,10 +4,6 @@ using DocStringExtensions: SIGNATURES
 using Base: Math.@horner, @irrational
 import LinearAlgebra
 
-# reexport logarithmic constants
-using IrrationalConstants: loghalf, logtwo, logπ, log2π, log4π
-export loghalf, logtwo, logπ, log2π, log4π
-
 export xlogx, xlogy, logistic, logit, log1psq, log1pexp, log1mexp, log2mexp, logexpm1,
     softplus, invsoftplus, log1pmx, logmxp1, logaddexp, logsubexp, logsumexp, softmax,
     softmax!

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -116,7 +116,7 @@ See:
 
 Note: different than Maechler (2012), no negation inside parentheses
 """
-log1mexp(x::Real) = x < loghalf ? log1p(-exp(x)) : log(-expm1(x))
+log1mexp(x::Real) = x < IrrationalConstants.loghalf ? log1p(-exp(x)) : log(-expm1(x))
 
 """
 $(SIGNATURES)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,7 +1,0 @@
-# mathematical constants related to statistics
-
-@irrational loghalf -0.6931471805599453094 log(big(0.5))
-@irrational logtwo 0.6931471805599453094 log(big(2.))
-@irrational logπ   1.1447298858494001741 log(big(π))
-@irrational log2π  1.8378770664093454836 log(big(2.)*π)
-@irrational log4π  2.5310242469692907930 log(big(4.)*π)


### PR DESCRIPTION
The constants in StatsFuns were moved to [IrrationalConstants](https://github.com/JuliaMath/IrrationalConstants.jl) such that other packages such as e.g. SpecialFunctions or DiffRules can make use of them without having to depend on StatsFuns. This PR ~~reexports the logarithmic constants in IrrationalConstants and~~ updates the documentation (also adds a missing docstring for `logsubexp` and fixes doctests which could be moved to a separate PR).

**Edit:** This PR removes the definition of the logarithmic constants in LogExpFunctions and uses the definitions in IrrationalConstants instead but does not reexport the constants defined in IrrationalConstants. Users and downstream packages should depend on IrrationalConstants directly.