### PR TITLE
Use ternary operator instead of ifelse

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -11,7 +11,7 @@ julia> xlogx(0)
 """
 function xlogx(x::Number)
     result = x * log(x)
-    ifelse(iszero(x), zero(result), result)
+    return iszero(x) ? zero(result) : result
 end
 
 """
@@ -26,7 +26,7 @@ julia> xlogy(0, 0)
 """
 function xlogy(x::Number, y::Number)
     result = x * log(y)
-    ifelse(iszero(x) && !isnan(y), zero(result), result)
+    return iszero(x) && !isnan(y) ? zero(result) : result
 end
 
 # The following bounds are precomputed versions of the following abstract
@@ -60,15 +60,7 @@ logistic(x::Real) = inv(exp(-x) + one(x))
 function logistic(x::Union{Float16, Float32, Float64})
     e = exp(x)
     lower, upper = _logistic_bounds(x)
-    ifelse(
-        x < lower,
-        zero(x),
-        ifelse(
-            x > upper,
-            one(x),
-            e / (one(x) + e)
-        )
-    )
+    return x < lower ? zero(x) : x > upper ? one(x) : e / (one(x) + e)
 end
 
 """
@@ -210,7 +202,7 @@ non-finite values.
 """
 function logaddexp(x::Real, y::Real)
     # ensure Δ = 0 if x = y = ± Inf
-    Δ = ifelse(x == y, zero(x - y), abs(x - y))
+    Δ = x == y ? zero(x - y) : abs(x - y)
     max(x, y) + log1pexp(-Δ)
 end
 


### PR DESCRIPTION
In benchmarks of https://github.com/JuliaStats/StatsBase.jl/pull/714 and the examples shown below it seems that on my computer the ternary operator is sometimes faster than `ifelse` (which evaluates all branches) and never slower:

With the latest release:
```julia
julia> using LogExpFunctions, BenchmarkTools, Random

julia> Random.seed!(1234);

julia> out = Vector{Float64}(undef,100_000);

julia> x, y = rand(100_000), rand(100_000);

julia> @btime map!(xlogx, $out, $x);
  717.358 μs (0 allocations: 0 bytes)

julia> @btime map!(xlogy, $out, $x, $y);
  780.322 μs (0 allocations: 0 bytes)

julia> @btime map!(logistic, $out, $x);
  745.426 μs (0 allocations: 0 bytes)

julia> @btime map!(logaddexp, $out, $x, $y);
  2.502 ms (0 allocations: 0 bytes)

julia> @btime sum(xlogx, $x); # similar to https://github.com/JuliaStats/StatsBase.jl/pull/714
  780.203 μs (0 allocations: 0 bytes)
```

With this PR:
```julia
julia> using LogExpFunctions, BenchmarkTools, Random

julia> Random.seed!(1234);

julia> out = Vector{Float64}(undef,100_000);

julia> x, y = rand(100_000), rand(100_000);

julia> @btime map!(xlogx, $out, $x);
  703.294 μs (0 allocations: 0 bytes)

julia> @btime map!(xlogy, $out, $x, $y);
  780.819 μs (0 allocations: 0 bytes)

julia> @btime map!(logistic, $out, $x);
  717.576 μs (0 allocations: 0 bytes)

julia> @btime map!(logaddexp, $out, $x, $y);
  2.507 ms (0 allocations: 0 bytes)

julia> @btime sum(xlogx, $x);
  762.913 μs (0 allocations: 0 bytes)
```
