### PR TITLE
Define inverse functions with InverseFunctions.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,19 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 ChainRulesCore = "1"
 DocStringExtensions = "0.8"
+InverseFunctions = "0.1"
 IrrationalConstants = "0.1"
 julia = "1"
 

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -4,6 +4,7 @@ using DocStringExtensions: SIGNATURES
 using Base: Math.@horner
 
 import ChainRulesCore
+import InverseFunctions
 import IrrationalConstants
 import LinearAlgebra
 
@@ -14,5 +15,6 @@ export xlogx, xlogy, xlog1py, logistic, logit, log1psq, log1pexp, log1mexp, log2
 include("basicfuns.jl")
 include("logsumexp.jl")
 include("chainrules.jl")
+include("inverse.jl")
 
 end # module

--- a/src/inverse.jl
+++ b/src/inverse.jl
@@ -1,0 +1,9 @@
+InverseFunctions.inverse(::typeof(log1pexp)) = logexpm1
+InverseFunctions.inverse(::typeof(logexpm1)) = log1pexp
+
+InverseFunctions.inverse(::typeof(log1mexp)) = log1mexp
+
+InverseFunctions.inverse(::typeof(log2mexp)) = log2mexp
+
+InverseFunctions.inverse(::typeof(logit)) = logistic
+InverseFunctions.inverse(::typeof(logistic)) = logit

--- a/test/inverse.jl
+++ b/test/inverse.jl
@@ -1,0 +1,11 @@
+@testset "inverse.jl" begin
+    InverseFunctions.test_inverse(log1pexp, randn())
+    InverseFunctions.test_inverse(logexpm1, randexp())
+
+    InverseFunctions.test_inverse(log1mexp, -randexp())
+
+    InverseFunctions.test_inverse(log2mexp, log(2) - randexp())
+
+    InverseFunctions.test_inverse(logistic, randn())
+    InverseFunctions.test_inverse(logit, rand())
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using LogExpFunctions
 using ChainRulesTestUtils
+using InverseFunctions
 using OffsetArrays
 
 using Random
@@ -9,3 +10,4 @@ Random.seed!(1234)
 
 include("basicfuns.jl")
 include("chainrules.jl")
+include("inverse.jl")


### PR DESCRIPTION
This PR adds an implementation of `InverseFunctions.inverse` for `log1pexp`, `logexpm1`, `log1mexp`, `log2mexp`, `logit`, and `logistic`.

[InverseFunctions](https://github.com/JuliaMath/InverseFunctions.jl) is a lightweight package with no external dependencies that only defines the `InverseFunctions.inverse` interface and implements it for functions from base such as `exp` or `log`. In many scenarios it is useful to be able to retrieve the inverse function to a given function automatically, and InverseFunctions provides an interface for this task. In particular, it would be very useful if this would work also for `log1pexp`/`logexpm1` and `logit`/`logistic` as then the former could be used e.g. in `ParameterHandling.positive` or in GPLikelihoods as a replacement for the standard exponential transformation to the positive real numbers, without any additional code or requirement in these packages. LogExpFunctions is the only place where `inverse` can be defined without committing type piracy.