### PR TITLE
Add support for ChangesOfVariables.with_logabsdet_jacobian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
@@ -12,6 +13,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 ChainRulesCore = "1"
+ChangesOfVariables = "0.1"
 DocStringExtensions = "0.8"
 InverseFunctions = "0.1"
 IrrationalConstants = "0.1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,6 +4,8 @@ Various special functions based on `log` and `exp` moved from [StatsFuns.jl](htt
 
 The original authors of these functions are the StatsFuns.jl contributors.
 
+LogExpFunctions supports [`InverseFunctions.inverse`](https://github.com/JuliaMath/InverseFunctions.jl) and [`ChangesOfVariables.test_with_logabsdet_jacobian`](https://github.com/JuliaMath/ChangesOfVariables.jl) for `log1mexp`, `log1pexp`, `log1pexp`, `log2mexp`, `log2mexp`, `logexpm1`, `logistic`, `logistic` and `logit`.
+
 ```@docs
 xlogx
 xlogy

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -4,6 +4,7 @@ using DocStringExtensions: SIGNATURES
 using Base: Math.@horner
 
 import ChainRulesCore
+import ChangesOfVariables
 import InverseFunctions
 import IrrationalConstants
 import LinearAlgebra
@@ -16,5 +17,6 @@ include("basicfuns.jl")
 include("logsumexp.jl")
 include("chainrules.jl")
 include("inverse.jl")
+include("with_logabsdet_jacobian.jl")
 
 end # module

--- a/src/with_logabsdet_jacobian.jl
+++ b/src/with_logabsdet_jacobian.jl
@@ -1,0 +1,43 @@
+function ChangesOfVariables.with_logabsdet_jacobian(::typeof(log1pexp), x::Real)
+    y = log1pexp(x)
+    return y, x - y
+end
+
+function ChangesOfVariables.with_logabsdet_jacobian(::typeof(logexpm1), x::Real)
+    y = logexpm1(x)
+    return y, (x - y)
+end
+
+function ChangesOfVariables.with_logabsdet_jacobian(::typeof(log1mexp), x::Real)
+    y = log1mexp(x)
+    return y, (x - y)
+end
+
+function ChangesOfVariables.with_logabsdet_jacobian(::typeof(log2mexp), x::Real)
+    y = log2mexp(x)
+    return y, (x - y)
+end
+
+function ChangesOfVariables.with_logabsdet_jacobian(::typeof(logit), x::Real)
+    y = logit(x)
+    y, log(inv(x * (1 - x)))
+end
+
+function ChangesOfVariables.with_logabsdet_jacobian(::typeof(logistic), x::Real)
+    y = logistic(x)
+    y, log(y * (1 - y))
+end
+
+
+#=
+ChainRulesCore.@scalar_rule(log1pexp(x::Real), (logistic(x),))
+ChainRulesCore.@scalar_rule(logexpm1(x::Real), (exp(x - Ω),))
+
+ChainRulesCore.@scalar_rule(log1mexp(x::Real), (-exp(x - Ω),))
+
+ChainRulesCore.@scalar_rule(log2mexp(x::Real), (-exp(x - Ω),))
+
+ChainRulesCore.@scalar_rule(logistic(x::Real), (Ω * (1 - Ω),))
+
+ChainRulesCore.@scalar_rule(logit(x::Real), (inv(x * (1 - x)),))
+=#

--- a/src/with_logabsdet_jacobian.jl
+++ b/src/with_logabsdet_jacobian.jl
@@ -5,39 +5,25 @@ end
 
 function ChangesOfVariables.with_logabsdet_jacobian(::typeof(logexpm1), x::Real)
     y = logexpm1(x)
-    return y, (x - y)
+    return y, x - y
 end
 
 function ChangesOfVariables.with_logabsdet_jacobian(::typeof(log1mexp), x::Real)
     y = log1mexp(x)
-    return y, (x - y)
+    return y, x - y
 end
 
 function ChangesOfVariables.with_logabsdet_jacobian(::typeof(log2mexp), x::Real)
     y = log2mexp(x)
-    return y, (x - y)
+    return y, x - y
 end
 
 function ChangesOfVariables.with_logabsdet_jacobian(::typeof(logit), x::Real)
     y = logit(x)
-    y, log(inv(x * (1 - x)))
+    y, -log(x * (1 - x))
 end
 
 function ChangesOfVariables.with_logabsdet_jacobian(::typeof(logistic), x::Real)
     y = logistic(x)
     y, log(y * (1 - y))
 end
-
-
-#=
-ChainRulesCore.@scalar_rule(log1pexp(x::Real), (logistic(x),))
-ChainRulesCore.@scalar_rule(logexpm1(x::Real), (exp(x - Ω),))
-
-ChainRulesCore.@scalar_rule(log1mexp(x::Real), (-exp(x - Ω),))
-
-ChainRulesCore.@scalar_rule(log2mexp(x::Real), (-exp(x - Ω),))
-
-ChainRulesCore.@scalar_rule(logistic(x::Real), (Ω * (1 - Ω),))
-
-ChainRulesCore.@scalar_rule(logit(x::Real), (inv(x * (1 - x)),))
-=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using LogExpFunctions
+using ChainRulesCore
 using ChainRulesTestUtils
+using ChangesOfVariables
 using InverseFunctions
 using OffsetArrays
 
@@ -11,3 +13,4 @@ Random.seed!(1234)
 include("basicfuns.jl")
 include("chainrules.jl")
 include("inverse.jl")
+include("with_logabsdet_jacobian.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using LogExpFunctions
-using ChainRulesCore
 using ChainRulesTestUtils
 using ChangesOfVariables
 using InverseFunctions

--- a/test/with_logabsdet_jacobian.jl
+++ b/test/with_logabsdet_jacobian.jl
@@ -1,4 +1,4 @@
-@testset "with_logabsdet_jacobian.jl" begin
+@testset "with_logabsdet_jacobian" begin
     derivative(f, x) = ChainRulesTestUtils.frule((ChainRulesTestUtils.NoTangent(), 1), f, x)[2]
 
     x = randexp()
@@ -11,7 +11,6 @@
     ChangesOfVariables.test_with_logabsdet_jacobian(log1mexp, -x, derivative)
 
     ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, log(2) - x, derivative)
-    ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, x - log(2), derivative)
 
     ChangesOfVariables.test_with_logabsdet_jacobian(logistic, -x, derivative)
     ChangesOfVariables.test_with_logabsdet_jacobian(logistic, x, derivative)

--- a/test/with_logabsdet_jacobian.jl
+++ b/test/with_logabsdet_jacobian.jl
@@ -1,20 +1,20 @@
 @testset "with_logabsdet_jacobian.jl" begin
-    derivative(f, x) = ChainRulesCore.frule((nothing,1), f, x)[2]
+    derivative(f, x) = ChainRulesTestUtils.frule((ChainRulesTestUtils.NoTangent(), 1), f, x)[2]
 
     x = randexp()
 
-    ChangesOfVariables.test_with_logabsdet_jacobian(log1pexp, +x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(log1pexp, x, derivative)
     ChangesOfVariables.test_with_logabsdet_jacobian(log1pexp, -x, derivative)
 
-    ChangesOfVariables.test_with_logabsdet_jacobian(logexpm1, +x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(logexpm1, x, derivative)
 
     ChangesOfVariables.test_with_logabsdet_jacobian(log1mexp, -x, derivative)
 
-    ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, +log(2) - x, derivative)
-    ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, -log(2) + x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, log(2) - x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, x - log(2), derivative)
 
     ChangesOfVariables.test_with_logabsdet_jacobian(logistic, -x, derivative)
-    ChangesOfVariables.test_with_logabsdet_jacobian(logistic, +x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(logistic, x, derivative)
 
     ChangesOfVariables.test_with_logabsdet_jacobian(logit, rand(), derivative)
 end

--- a/test/with_logabsdet_jacobian.jl
+++ b/test/with_logabsdet_jacobian.jl
@@ -1,0 +1,20 @@
+@testset "with_logabsdet_jacobian.jl" begin
+    derivative(f, x) = ChainRulesCore.frule((nothing,1), f, x)[2]
+
+    x = randexp()
+
+    ChangesOfVariables.test_with_logabsdet_jacobian(log1pexp, +x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(log1pexp, -x, derivative)
+
+    ChangesOfVariables.test_with_logabsdet_jacobian(logexpm1, +x, derivative)
+
+    ChangesOfVariables.test_with_logabsdet_jacobian(log1mexp, -x, derivative)
+
+    ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, +log(2) - x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(log2mexp, -log(2) + x, derivative)
+
+    ChangesOfVariables.test_with_logabsdet_jacobian(logistic, -x, derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(logistic, +x, derivative)
+
+    ChangesOfVariables.test_with_logabsdet_jacobian(logit, rand(), derivative)
+end


### PR DESCRIPTION
This PR adds support for `ChangesOfVariables.test_with_logabsdet_jacobian` to functions in LogExpFunctions that already support `InverseFunctions.inverse`.

This complements #29: [InverseFunctions](https://github.com/JuliaMath/InverseFunctions.jl) and [ChangesOfVariables](https://github.com/JuliaMath/ChangesOfVariables.jl) were designed in tandem (both are extremely lightweight packages) to support variable transformations. Applications that perform variable transformations often need the volume element of the transformation in addition to the result and the inverse of the transformation. `ChangesOfVariables.with_logabsdet_jacobian(f, x)` delivers that capability, it returns the equivalent of `f(x), logabsdet(jacobian(f, x))`

 With this PR, fun stuff like this works out of the box:

```julia
using LogExpFunctions, InverseFunctions, ChangesOfVariables

X = rand(5)
trafo = Base.Fix1(broadcast, logit)

Y, ladj = with_logabsdet_jacobian(trafo, X)

X2, ladj2 = with_logabsdet_jacobian(inverse(trafo), Y)

@assert X ≈ X2 ≈ logistic.(Y) && ladj ≈ -ladj2
```

Packages like Bijectors that use `logistic` and `logit` in transformations can profit directly from implementing `with_logabsdet_jacobian` in LogExpFunctions  (Bijectors will support `InverseFunctions` and `ChangesOfVariables` soon, see TuringLang/Bijectors.jl#199).


This PR has no significant effect on the load time of LogExpFunctions (`@time using LogExpFunctions` showed 0.47 s without and 0.45 s with this PR).


CC @devmotion, @torfjelde, @willtebbutt