### PR TITLE
xexpx, xexpy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,6 +10,8 @@ LogExpFunctions supports [`InverseFunctions.inverse`](https://github.com/JuliaMa
 xlogx
 xlogy
 xlog1py
+xexpx
+xexpy
 logistic
 logit
 logcosh

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -9,7 +9,7 @@ import InverseFunctions
 import IrrationalConstants
 import LinearAlgebra
 
-export xlogx, xlogy, xlog1py, logistic, logit, log1psq, log1pexp, log1mexp, log2mexp, logexpm1,
+export xlogx, xlogy, xlog1py, xexpx, xexpy, logistic, logit, log1psq, log1pexp, log1mexp, log2mexp, logexpm1,
     softplus, invsoftplus, log1pmx, logmxp1, logaddexp, logsubexp, logsumexp, softmax,
     softmax!, logcosh
 

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -44,6 +44,37 @@ function xlog1py(x::Number, y::Number)
     return iszero(x) && !isnan(y) ? zero(result) : result
 end
 
+"""
+$(SIGNATURES)
+
+Return `x * exp(x)` for `x > -Inf`, or zero if `x == -Inf`.
+
+```jldoctest
+julia> xexpx(-Inf)
+0.0
+```
+"""
+function xexpx(x::Real)
+    expx = exp(x)
+    return iszero(expx) ? expx : x * expx
+end
+
+"""
+$(SIGNATURES)
+
+Return `x * exp(y)` for `y > -Inf`, or zero if `y == -Inf`.
+
+```jldoctest
+julia> xexpy(1.0, -Inf)
+0.0
+```
+"""
+function xexpy(x::Real, y::Real)
+    expy = exp(y)
+    result = x * expy
+    return iszero(expy) && !isnan(x) ? zero(result) : result
+end
+
 # The following bounds are precomputed versions of the following abstract
 # function, but the implicit interface for AbstractFloat doesn't uniformly
 # enforce that all floating point types implement nextfloat and prevfloat.

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -44,6 +44,37 @@
     @test iszero(xlog1py(0 + im * 0, -1 + im * Inf))
 end
 
+@testset "xexpx" begin
+    for x in (false, 0, 0.0, 0f0, -Inf, -Inf32)
+        @test (@inferred xexpx(x)) === zero(exp(x))
+    end
+    for x in (NaN16, NaN32, NaN64, Inf16, Inf32, Inf64)
+        @test (@inferred xexpx(x)) === x
+    end
+    for x in (1, true, 1.0, 1f0)
+        @test (@inferred xexpx(x)) === exp(x)
+    end
+    for a in (2, 2f0, 2.0), x in -a:a
+        @test (@inferred xexpx(x)) === x * exp(x)
+    end
+end
+
+@testset "xexpy" begin
+    for x in (0, 1, 1.0, 1f0, Inf, Inf32), y in (-Inf, -Inf32)
+        @test (@inferred xexpy(x, y)) === zero(x * exp(y))
+    end
+    for x in (0, 1, 1.0, 1f0, Inf, Inf32, -Inf, -Inf32, NaN, NaN32), nan in (NaN, NaN32)
+        @test (@inferred xexpy(x, nan)) === oftype(x * exp(nan), NaN)
+        @test (@inferred xexpy(nan, x)) === oftype(nan * exp(x), NaN)
+    end
+    for x in (2, -2f0, 2.0), y in (1, -1f0, 1.0)
+        @test (@inferred xexpy(x, y)) ≈ x * exp(y)
+    end
+    for x in (randn(), randn(Float32))
+        @test xexpy(x, x) ≈ xexpx(x)
+    end
+end
+
 @testset "logistic & logit" begin
     @test logistic(2) ≈ 1.0 / (1.0 + exp(-2.0))
     @test logistic(-750.0) === 0.0

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -13,6 +13,27 @@
         end
     end
 
+    @testset "xexpx" begin
+        # regular branch
+        test_scalar(xexpx, randn())
+        # special cases (manually since FiniteDifferences/ChainRulesTestUtils fails at -Inf)
+        @test @inferred(frule((NoTangent(), rand()), xexpx, -Inf)) === (0.0, 0.0)
+        Ω, back = @inferred(rrule(xexpx, -Inf))
+        @test Ω === 0.0
+        @test back(rand()) === (NoTangent(), 0.0)
+    end
+
+    @testset "xexpy" begin
+        # regular branch
+        test_frule(xexpy, randn(), randn())
+        test_rrule(xexpy, randn(), randn())
+        # special cases (manually since FiniteDifferences/ChainRulesTestUtils fails at -Inf)
+        @test @inferred(frule((NoTangent(), rand(), rand()), xexpy, x, -Inf)) === (0.0, 0.0)
+        Ω, back = @inferred(rrule(xexpy, x, -Inf))
+        @test Ω === 0.0
+        @test back(rand()) === (NoTangent(), 0.0, 0.0)
+    end
+
     test_frule(logit, x)
     test_rrule(logit, x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using LogExpFunctions
 using ChainRulesTestUtils
+using ChainRulesCore
 using ChangesOfVariables
 using InverseFunctions
 using OffsetArrays


### PR DESCRIPTION
Adds functions `xexpx(x)` and `xexpy(x, y)`, which compute `x * exp(x)` and `x * exp(y)`, respectively, but taking the "correct" limit when the exponent is infinite.

Close #15 .