### PR TITLE
logsumexp!(r, X)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,6 +24,7 @@ log1pmx
 logmxp1
 logaddexp
 logsubexp
+logsumexp!
 logsumexp
 softmax!
 softmax

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -10,8 +10,8 @@ import IrrationalConstants
 import LinearAlgebra
 
 export xlogx, xlogy, xlog1py, xexpx, xexpy, logistic, logit, log1psq, log1pexp, log1mexp, log2mexp, logexpm1,
-    softplus, invsoftplus, log1pmx, logmxp1, logaddexp, logsubexp, logsumexp, softmax,
-    softmax!, logcosh
+    softplus, invsoftplus, log1pmx, logmxp1, logaddexp, logsubexp, logsumexp, logsumexp!,
+    softmax, softmax!, logcosh
 
 include("basicfuns.jl")
 include("logsumexp.jl")

--- a/src/logsumexp.jl
+++ b/src/logsumexp.jl
@@ -126,3 +126,17 @@ function _logsumexp_onepass_op(xmax1::T, xmax2::T, r1::R, r2::R) where {T<:Numbe
     end
     return xmax, r
 end
+
+"""
+$(SIGNATURES)
+
+Compute `log.(sum!(r, exp.(X); dims=dims))`, summing over the singleton dimensions of `r`,
+and overwriting `r` with the results.
+The calculation is done in a numerically stable way that avoids intermediate
+over- and underflow.
+"""
+function logsumexp!(r::AbstractArray, X::AbstractArray)
+	m = maximum!(similar(r), X)
+	sum!(r, exp.(X .- m))
+	return r .= log.(r) .+ m
+end

--- a/src/logsumexp.jl
+++ b/src/logsumexp.jl
@@ -136,7 +136,7 @@ The calculation is done in a numerically stable way that avoids intermediate
 over- and underflow.
 """
 function logsumexp!(r::AbstractArray, X::AbstractArray)
-	m = maximum!(similar(r), X)
-	sum!(r, exp.(X .- m))
-	return r .= log.(r) .+ m
+    m = maximum!(similar(r), X)
+    sum!(r, exp.(X .- m))
+    return r .= log.(r) .+ m
 end

--- a/src/logsumexp.jl
+++ b/src/logsumexp.jl
@@ -137,6 +137,7 @@ over- and underflow.
 """
 function logsumexp!(r::AbstractArray, X::AbstractArray)
     m = maximum!(similar(r), X)
-    sum!(r, exp.(X .- m))
-    return r .= log.(r) .+ m
+    c = sum!(similar(r), X .== m)
+    sum!(r, (X .< m) .* exp.(X .- m))
+    return r .= log.(c) .+ log1p.(r ./ c) .+ m
 end

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -271,6 +271,11 @@ end
     r = randn(1,3,2)
     @inferred logsumexp!(r, X)
     @test r ≈ logsumexp(X; dims=1)
+
+    X = [1e-20, log(1e-20)]
+    r = [1.3]
+    @inferred logsumexp!(r, X)
+    @test_broken r ≈ logsumexp(X; dims=1)
 end
 
 @testset "softmax" begin

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -266,6 +266,13 @@ end
     @test @inferred(logsumexp(x for x in xs)) == logsumexp(xs)
 end
 
+@testset "logsumexp!" begin
+    X = randn(4,3,2)
+    r = randn(1,3,2)
+    @inferred logsumexp!(r, X)
+    @test r ≈ logsumexp(X; dims=1)
+end
+
 @testset "softmax" begin
     x = [1.0, 2.0, 3.0]
     r = exp.(x) ./ sum(exp.(x))

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -275,7 +275,7 @@ end
     X = [1e-20, log(1e-20)]
     r = [1.3]
     @inferred logsumexp!(r, X)
-    @test_broken r ≈ logsumexp(X; dims=1)
+    @test r ≈ logsumexp(X; dims=1)
 end
 
 @testset "softmax" begin


### PR DESCRIPTION
Add `logsumexp!(r, X)`, in-place version of `logsumexp`.

From the docstring:

```
Compute `log.(sum!(r, exp.(X); dims=dims))`, summing over the singleton dimensions of `r`,
and overwriting `r` with the results.
The calculation is done in a numerically stable way that avoids intermediate
over- and underflow.
```

Close #14 .