### PR TITLE
new implementation of logaddexp

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -309,9 +309,22 @@ Return `log(exp(x) + exp(y))`, avoiding intermediate overflow/undeflow, and hand
 non-finite values.
 """
 function logaddexp(x::Real, y::Real)
-    # ensure Δ = 0 if x = y = ± Inf
-    Δ = x == y ? zero(x - y) : abs(x - y)
-    max(x, y) + log1pexp(-Δ)
+    if isnan(x) return x end
+    if isnan(y) return y end
+
+    diff = zero(promote_type(typeof(x), typeof(y)))
+    if x < y
+        diff = x - y
+        x = y
+    else
+        diff = y - x
+    end
+
+    if diff >= log(eps())
+        return x + log1p(exp(diff))
+    else
+        return x
+    end
 end
 
 Base.@deprecate logsumexp(x::Real, y::Real) logaddexp(x, y)


### PR DESCRIPTION
This pull request proposes a new implementation of `logaddexp` which is much faster than the current one.

Here is a small benchmark to illustrate the benefit:
```
julia> using LogExpFunctions
julia> using BenchmarkTools
julia> function logaddexp_new(x, y)
         if isnan(x) return x end
             if isnan(y) return y end
  
             diff = zero(promote_type(typeof(x), typeof(y)))
             if x < y
                 diff = x - y
                 x = y
             else
                 diff = y - x
             end
  
             if diff >= log(eps())
                 return x + log1p(exp(diff))
             else
                 return x
             end
       end;
julia> function logaddexp_old(x, y)
         Δ = x == y ? zero(x - y) : abs(x - y)
         return max(x, y) + log1pexp(-Δ)                                                              
       end;
julia> x = 1000*randn(100000);
julia> y = 1000*randn(100000);
julia> @benchmark logaddexp_old.(x, y)
BenchmarkTools.Trial: 2722 samples with 1 evaluation.
 Range (min … max):  1.813 ms …  2.113 ms  ┊ GC (min … max): 0.00% … 12.46%
 Time  (median):     1.827 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.834 ms ± 34.028 μs  ┊ GC (mean ± σ):  0.23% ±  1.54%

  ▁█▄▃▁                                                       
  ██████▆▅▄▃▃▂▂▂▂▂▂▂▁▁▁▁▂▁▁▁▁▁▂▁▂▂▁▁▁▁▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▂▂▂▂ ▃
  1.81 ms        Histogram: frequency by time        2.08 ms <

 Memory estimate: 781.36 KiB, allocs estimate: 4.
 julia> @benchmark logaddexp_new.(x, y)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  296.166 μs … 492.875 μs  ┊ GC (min … max): 0.00% … 39.48%
 Time  (median):     297.042 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   300.727 μs ±  24.536 μs  ┊ GC (mean ± σ):  1.07% ±  5.01%

  █▅                                                            ▁
  ██▇▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▆▅█ █
  296 μs        Histogram: log(frequency) by time        486 μs <

 Memory estimate: 781.36 KiB, allocs estimate: 4.
```