### PR TITLE
Add threshold for zero results in `log1pexp`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.3.10"
+version = "0.3.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -128,6 +128,17 @@ end
     @test iszero(@inferred log1pexp(-1e4))
     @test iszero(@inferred log1pexp(-1f4))
 
+    # (almost) zero results
+    for T in (Float16, Float32, Float64)
+        @test @inferred(log1pexp(log(nextfloat(zero(T))))) === nextfloat(zero(T))
+        @test @inferred(log1pexp(log(nextfloat(zero(T))) - 1)) === zero(T)
+    end
+
+    # hard-coded thresholds
+    for T in (Float16, Float32, Float64)
+        @test LogExpFunctions._log1pexp_thresholds(zero(T)) === invoke(LogExpFunctions._log1pexp_thresholds, Tuple{Real}, zero(T))
+    end
+
     # compare to accurate but slower implementation
     correct_log1pexp(x::Real) = x > 0 ? x + log1p(exp(-x)) : log1p(exp(x))
     # large range needed to cover all branches, for all floats (from Float16 to BigFloat)

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -129,9 +129,8 @@ end
     @test iszero(@inferred log1pexp(-1f4))
 
     # (almost) zero results
-    for T in (Float16, Float32, Float64)
-        @test @inferred(log1pexp(log(nextfloat(zero(T))))) === nextfloat(zero(T))
-        @test @inferred(log1pexp(log(nextfloat(zero(T))) - 1)) === zero(T)
+    for T in (Float16, Float32, Float64), x in (log(nextfloat(zero(T))), log(nextfloat(zero(T))) - 1)
+        @test @inferred(log1pexp(x)) === log1p(exp(x))
     end
 
     # hard-coded thresholds


### PR DESCRIPTION
Motivated by the approach in https://github.com/JuliaStats/LogExpFunctions.jl/pull/41, this PR adds an additional branch to `log1pexp` that improves performance for large negative numbers for which `iszero(log1pexp(x))` (in floating point arithmetic).

This avoids an `exp` call which improves performance:

On the master branch:
```julia
julia> using LogExpFunctions, BenchmarkTools

julia> x = -1_000.0;

julia> @btime log1pexp($x);
  4.289 ns (0 allocations: 0 bytes)

julia> x = -40.0;

julia> @btime log1pexp($x);
  3.861 ns (0 allocations: 0 bytes)

julia> x = 0.0;

julia> @btime log1pexp($x);
  12.676 ns (0 allocations: 0 bytes)

julia> x = 30.0;

julia> @btime log1pexp($x);
  4.705 ns (0 allocations: 0 bytes)

julia> x = 40.0;

julia> @btime log1pexp($x);
  1.295 ns (0 allocations: 0 bytes)
```

With this PR:
```julia
julia> using LogExpFunctions, BenchmarkTools

julia> x = -1_000.0;

julia> @btime log1pexp($x);
  1.289 ns (0 allocations: 0 bytes)

julia> x = -40.0;

julia> @btime log1pexp($x);
  4.072 ns (0 allocations: 0 bytes)

julia> x = 0.0;

julia> @btime log1pexp($x);
  12.980 ns (0 allocations: 0 bytes)

julia> x = 30.0;

julia> @btime log1pexp($x);
  4.707 ns (0 allocations: 0 bytes)

julia> x = 40.0;

julia> @btime log1pexp($x);
  1.300 ns (0 allocations: 0 bytes)
```