### PR TITLE
Reuse intermediate result of primal in derivative

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.3.14"
+version = "0.3.15"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Similar to the existing ChainRules definitions for `xexpx` and `xexpy`, and inspired by https://github.com/FluxML/Zygote.jl/blob/master/src/lib/logexpfunctions.jl, this PR improves the ChainRules definitions of `xlogx`, `xlogy`, and `xlog1py` by reusing intermediate results of the computation of the primal when calculating the partial derivatives.