### PR TITLE
Add `iszero(x)` branches to `xlogy` and `xlog1py`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,9 +21,10 @@ julia = "1"
 
 [extras]
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesTestUtils", "OffsetArrays", "Random", "Test"]
+test = ["ChainRulesTestUtils", "FiniteDifferences", "OffsetArrays", "Random", "Test"]

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -19,9 +19,15 @@ end
 function _Ω_∂_xlogy(x::Real, y::Real)
     logy = log(y)
     z = x * logy
-    Ω = iszero(x) && !isnan(y) ? zero(z) : z
-    ∂x = logy
-    ∂y = x / y
+    w = x / y
+    if iszero(x) && !isnan(y)
+        Ω = zero(z)
+        ∂y = zero(w)
+    else
+        Ω = z
+        ∂y = iszero(y) ? oftype(w, NaN) : w
+    end
+    ∂x = iszero(y) ? oftype(logy, NaN) : logy
     return Ω, ∂x, ∂y
 end
 function ChainRulesCore.frule((_, Δx, Δy), ::typeof(xlogy), x::Real, y::Real)
@@ -38,9 +44,16 @@ end
 function _Ω_∂_xlog1py(x::Real, y::Real)
     log1py = log1p(y)
     z = x * log1py
-    Ω = iszero(x) && !isnan(y) ? zero(z) : z
-    ∂x = log1py
-    ∂y = x / (1 + y)
+    yp1 = 1 + y
+    w = x / yp1
+    if iszero(x) && !isnan(y)
+        Ω = zero(z)
+        ∂y = zero(z)
+    else
+        Ω = z
+        ∂y = iszero(yp1) ? oftype(w, NaN) : w
+    end
+    ∂x = iszero(yp1) ? oftype(log1py, NaN) : log1py
     return Ω, ∂x, ∂y
 end
 function ChainRulesCore.frule((_, Δx, Δy), ::typeof(xlog1py), x::Real, y::Real)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -7,10 +7,16 @@
         test_frule(xlogy, x, y)
         test_rrule(xlogy, x, y)
 
+        test_frule(xlogy, x, 0.0; fdm = forward_fdm(5, 1), nans = true)
+        test_rrule(xlogy, x, 0.0; fdm = forward_fdm(5, 1), nans = true)
+
         for z in (-y, y)
             test_frule(xlog1py, x, z)
             test_rrule(xlog1py, x, z)
         end
+
+        test_frule(xlog1py, x, -1.0; fdm = forward_fdm(5, 1), nans = true)
+        test_rrule(xlog1py, x, -1.0; fdm = forward_fdm(5, 1), nans = true)
     end
 
     @testset "xexpx" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using LogExpFunctions
 using ChainRulesTestUtils
 using ChainRulesCore
 using ChangesOfVariables
+using FiniteDifferences
 using InverseFunctions
 using OffsetArrays
 


### PR DESCRIPTION
Some of the tests don't pass yet. Maybe a finite differencing setup issue, I don't know. I'll take another look tomorrow or next week.