### PR TITLE
Make ChainRulesCore, ChangesOfVariables, and InverseFunctions weak dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.3.19"
+version = "0.3.20"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -10,6 +10,16 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[weakdeps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[extensions]
+ChainRulesCoreExt = "ChainRulesCore"
+ChangesOfVariablesExt = "ChangesOfVariables"
+InverseFunctionsExt = "InverseFunctions"
 
 [compat]
 ChainRulesCore = "1"
@@ -20,12 +30,15 @@ IrrationalConstants = "0.1"
 julia = "1"
 
 [extras]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
+ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesTestUtils", "FiniteDifferences", "ForwardDiff", "OffsetArrays", "Random", "Test"]
+test = ["ChainRulesCore", "ChainRulesTestUtils", "ChangesOfVariables", "FiniteDifferences", "ForwardDiff", "InverseFunctions", "OffsetArrays", "Random", "Test"]

--- a/ext/ChainRulesCoreExt.jl
+++ b/ext/ChainRulesCoreExt.jl
@@ -1,3 +1,10 @@
+module ChainRulesCoreExt
+
+using LogExpFunctions
+import ChainRulesCore
+
+import LinearAlgebra
+
 function _Ω_∂_xlogx(x::Real)
     logx = log(x)
     y = x * logx
@@ -178,3 +185,5 @@ end
 
 ChainRulesCore.@scalar_rule(cloglog(x), (-inv((1 - x) * log1p(-x)),))
 ChainRulesCore.@scalar_rule(cexpexp(x), (-xexpx(-exp(x)),))
+
+end # module

--- a/ext/ChangesOfVariablesExt.jl
+++ b/ext/ChangesOfVariablesExt.jl
@@ -1,3 +1,9 @@
+module ChangesOfVariablesExt
+
+using LogExpFunctions
+import ChangesOfVariables
+import IrrationalConstants
+
 function ChangesOfVariables.with_logabsdet_jacobian(::typeof(log1pexp), x::Real)
     y = log1pexp(x)
     return y, x - y
@@ -35,3 +41,5 @@ function ChangesOfVariables.with_logabsdet_jacobian(::typeof(logcosh), x::Real)
     y = abs_x + z - IrrationalConstants.logtwo
     return y, log1mexp(a) - z
 end
+
+end # module

--- a/ext/InverseFunctionsExt.jl
+++ b/ext/InverseFunctionsExt.jl
@@ -1,3 +1,8 @@
+module InverseFunctionsExt
+
+using LogExpFunctions
+import InverseFunctions
+
 InverseFunctions.inverse(::typeof(log1pexp)) = logexpm1
 InverseFunctions.inverse(::typeof(logexpm1)) = log1pexp
 
@@ -10,3 +15,5 @@ InverseFunctions.inverse(::typeof(logistic)) = logit
 
 InverseFunctions.inverse(::typeof(cloglog)) = cexpexp
 InverseFunctions.inverse(::typeof(cexpexp)) = cloglog
+
+end # module

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -3,9 +3,6 @@ module LogExpFunctions
 using DocStringExtensions: SIGNATURES
 using Base: Math.@horner
 
-import ChainRulesCore
-import ChangesOfVariables
-import InverseFunctions
 import IrrationalConstants
 import LinearAlgebra
 
@@ -15,8 +12,11 @@ export xlogx, xlogy, xlog1py, xexpx, xexpy, logistic, logit, log1psq, log1pexp, 
 
 include("basicfuns.jl")
 include("logsumexp.jl")
-include("chainrules.jl")
-include("inverse.jl")
-include("with_logabsdet_jacobian.jl")
+
+if !isdefined(Base, :get_extension)
+    include("../ext/ChainRulesCoreExt.jl")
+    include("../ext/ChangesOfVariablesExt.jl")
+    include("../ext/InverseFunctionsExt.jl")
+end
 
 end # module


### PR DESCRIPTION
By doing so, on Julia >= 1.9 support for these packages will be loaded only when the packages are loaded by the user (or some other package). Some more info about weak dependencies: https://pkgdocs.julialang.org/dev/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)

The PR is based on https://github.com/JuliaMath/SpecialFunctions.jl/pull/421 and https://github.com/JuliaStats/StatsFuns.jl/pull/153.