### PR TITLE
tweak how some packages are loaded in extensions

### DIFF
--- a/ext/ChainRulesCoreExt.jl
+++ b/ext/ChainRulesCoreExt.jl
@@ -3,7 +3,7 @@ module ChainRulesCoreExt
 using LogExpFunctions
 import ChainRulesCore
 
-import LinearAlgebra
+import LogExpFunctions.LinearAlgebra
 
 function _Ω_∂_xlogx(x::Real)
     logx = log(x)

--- a/ext/ChangesOfVariablesExt.jl
+++ b/ext/ChangesOfVariablesExt.jl
@@ -2,7 +2,7 @@ module ChangesOfVariablesExt
 
 using LogExpFunctions
 import ChangesOfVariables
-import IrrationalConstants
+import LogExpFunctions.IrrationalConstants
 
 function ChangesOfVariables.with_logabsdet_jacobian(::typeof(log1pexp), x::Real)
     y = log1pexp(x)


### PR DESCRIPTION
Due to https://github.com/JuliaLang/julia/issues/48533, it might have to be necessary to disable packages loading other dependencies other than their weak dependencies and the parent package. The rest of the packages have to be transitively loaded from the parent package. This does this fix for the packages loaded in the extensions.

cc @vtjnash