### PR TITLE
refactor: prefix extensions with package name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,9 @@ ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [extensions]
-ChainRulesCoreExt = "ChainRulesCore"
-ChangesOfVariablesExt = "ChangesOfVariables"
-InverseFunctionsExt = "InverseFunctions"
+LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
 
 [compat]
 ChainRulesCore = "1"

--- a/ext/LogExpFunctionsChainRulesCoreExt.jl
+++ b/ext/LogExpFunctionsChainRulesCoreExt.jl
@@ -1,4 +1,4 @@
-module ChainRulesCoreExt
+module LogExpFunctionsChainRulesCoreExt
 
 using LogExpFunctions
 import ChainRulesCore

--- a/ext/LogExpFunctionsChangesOfVariablesExt.jl
+++ b/ext/LogExpFunctionsChangesOfVariablesExt.jl
@@ -1,4 +1,4 @@
-module ChangesOfVariablesExt
+module LogExpFunctionsChangesOfVariablesExt
 
 using LogExpFunctions
 import ChangesOfVariables

--- a/ext/LogExpFunctionsInverseFunctionsExt.jl
+++ b/ext/LogExpFunctionsInverseFunctionsExt.jl
@@ -1,4 +1,4 @@
-module InverseFunctionsExt
+module LogExpFunctionsInverseFunctionsExt
 
 using LogExpFunctions
 import InverseFunctions

--- a/src/LogExpFunctions.jl
+++ b/src/LogExpFunctions.jl
@@ -14,9 +14,9 @@ include("basicfuns.jl")
 include("logsumexp.jl")
 
 if !isdefined(Base, :get_extension)
-    include("../ext/ChainRulesCoreExt.jl")
-    include("../ext/ChangesOfVariablesExt.jl")
-    include("../ext/InverseFunctionsExt.jl")
+    include("../ext/LogExpFunctionsChainRulesCoreExt.jl")
+    include("../ext/LogExpFunctionsChangesOfVariablesExt.jl")
+    include("../ext/LogExpFunctionsInverseFunctionsExt.jl")
 end
 
 end # module


### PR DESCRIPTION
- this will ensure extension names are unique
- whenever there is another package with same ext name, building sysimage fails
- ex: ChangeOfVariables has its own ChainRulesCoreExt.jl

Ex: https://github.com/SciML/DiffEqBase.jl/tree/master/ext follows this for above mentioned reasons