### PR TITLE
Support IrrationalConstants 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.3.22"
+version = "0.3.23"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -26,7 +26,7 @@ ChainRulesCore = "1"
 ChangesOfVariables = "0.1"
 DocStringExtensions = "0.8, 0.9"
 InverseFunctions = "0.1"
-IrrationalConstants = "0.1"
+IrrationalConstants = "0.1, 0.2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
IrrationalConstants changed the type of the irrational constants to fix type piracy: https://github.com/JuliaMath/IrrationalConstants.jl/pull/19