### PR TITLE
Fix CUDA issue with irrational constant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogExpFunctions"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 authors = ["StatsFun.jl contributors, Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.3.24"
+version = "0.3.25"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -231,7 +231,15 @@ See:
 
 Note: different than Maechler (2012), no negation inside parentheses
 """
-log1mexp(x::Real) = x < IrrationalConstants.loghalf ? log1p(-exp(x)) : log(-expm1(x))
+function log1mexp(x::Real)
+    # Use explicit `oftype(..)` instead of just `loghalf` to avoid CUDA issues:
+    # https://github.com/JuliaStats/LogExpFunctions.jl/issues/73
+    if x < oftype(float(x), IrrationalConstants.loghalf)
+        return log1p(-exp(x))
+    else
+        return log(-expm1(x))
+    end
+end
 
 """
 $(SIGNATURES)


### PR DESCRIPTION
I think upstream fixes for #73 might take a while. Since we only use a heuristic here, it should be fine to just promote the irrational to the same (floating-point) type of the input `x` before comparing it with `x`.

@Red-Portal can you confirm that this PR fixes your issue? Seemed to be the case for me at least.