### PR TITLE
relax the doc string of `log2mexp`

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -247,7 +247,7 @@ end
 """
 $(SIGNATURES)
 
-Return `log(2 - exp(x))` evaluated as `log1p(-expm1(x))`
+Return `log(2 - exp(x))` evaluated carefully.
 """
 log2mexp(x::Real) = log1p(-expm1(x))
 


### PR DESCRIPTION
Breaking: prevent the doc string from promising the exact current implementation, to enable possible accuracy improvements in the future.

Updates #102