### PR TITLE
Add source path for LogExpFunctions in docs/Project.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,6 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
       - run: |
           julia --project=docs -e '

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,3 +4,6 @@ LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 
 [compat]
 Documenter = "1"
+
+[sources]
+LogExpFunctions = { path = ".." }


### PR DESCRIPTION
Possibly an alternative to #113 